### PR TITLE
UserData's relation column is not user_id

### DIFF
--- a/app/Models/UserData.php
+++ b/app/Models/UserData.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Cache;
 
 class UserData extends Model
 {
-    use BelongsToUserTrait;
     protected $table = 'user_data';
 
     public $timestamps = false;
@@ -92,14 +91,15 @@ class UserData extends Model
         return round($this->adoptions / $this->answers, 2) * 100;
     }
 
-
-
-
-
-
-
-
-
+    /**
+     * Get the user relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'id', 'id');
+    }
 
 
 }


### PR DESCRIPTION
- [x] App\Models\UserData 的用户关系不是通过user_id的字段，而是id